### PR TITLE
Feature/16 add universal audio model

### DIFF
--- a/app/api/lib/vk/api/vk.js
+++ b/app/api/lib/vk/api/vk.js
@@ -448,6 +448,18 @@ VK.prototype.initStats = function() {
 
 
 /**
+ * @param {number} ownerId
+ * @param {string} trackId
+ * @return {Promise.<string>}
+ */
+VK.prototype.getAudioTrackById = function(ownerId, trackId) {
+	var body = 'audio.getById' +
+		'?audios=' + ownerId + '_' + trackId;
+	return this._requestWrapper(body);
+};
+
+
+/**
  * @param {AudioTrack} track
  * @param {number} count
  * @return {Promise.<Array.<*>>}

--- a/app/api/lib/yandex-music/api/yandex-music.js
+++ b/app/api/lib/yandex-music/api/yandex-music.js
@@ -227,12 +227,13 @@ YandexMusic.prototype.getGenres = function() {
 
 
 /**
- * @param {models.Track} track
+ * @param {number} id
+ * @param {string} storageDir
  * @return {Promise.<string>}
  */
-YandexMusic.prototype.getTrackUrl = function(track) {
+YandexMusic.prototype.getTrackUrl = function(id, storageDir) {
 	var head = 'http://storage.music.yandex.ru/get/storage';
-	var body = track.storageDir;
+	var body = storageDir;
 	var tail = '2.xml';
 	var url = head + '/' + body + '/' + tail;
 
@@ -241,7 +242,7 @@ YandexMusic.prototype.getTrackUrl = function(track) {
 		.then(function(response) {
 			response = xml.parseString(response);
 			var fileName = response.attrib.filename;
-			var url = 'http://storage.music.yandex.ru/download-info/' + track.storageDir + '/' + fileName;
+			var url = 'http://storage.music.yandex.ru/download-info/' + storageDir + '/' + fileName;
 			return this._request(url);
 		}.bind(this))
 		.then(function(response) {
@@ -255,7 +256,7 @@ YandexMusic.prototype.getTrackUrl = function(track) {
 			var token = this.getMagicHash(path.substr(1) + s);
 
 			if (token) {
-				return 'http://'+ host + '/get-mp3/' + token + '/' + ts + path + '?track-id=' + track.id + '&play=false';
+				return 'http://'+ host + '/get-mp3/' + token + '/' + ts + path + '?track-id=' + id + '&play=false';
 			} else {
 				return null;
 			}

--- a/app/api/lib/yandex-music/models/lib/abstract-model.js
+++ b/app/api/lib/yandex-music/models/lib/abstract-model.js
@@ -20,8 +20,8 @@ goog.inherits(AbstractModel, events.EventEmitter);
 /**
  * @param {INPUT_TYPE} data
  */
-AbstractModel.prototype.parse = function(date) {
-	date = date || {};
+AbstractModel.prototype.parse = function(data) {
+	data = data || {};
 };
 
 

--- a/app/index.js
+++ b/app/index.js
@@ -6,4 +6,6 @@ vknp.ui = vknp.UI.namespace;
 vknp.service = require('./service');
 vknp.models = require('./models');
 
+vknp.Promise = require('promise');
+
 module.exports = require('./lib/app');

--- a/app/lib/app.js
+++ b/app/lib/app.js
@@ -107,8 +107,7 @@ Vknp.prototype.search = function(playlistId, count, query) {
 	return this.api.vk.audioSearch(query, count)
 		.then(function(tracks) {
 			tracks = this._scythe(tracks, query);
-			this.service.playListManager.clear(playlistId);
-			return this.service.playListManager.addItems(playlistId, tracks, true);//todo mb setItems
+			return this.service.playListManager.setItems(playlistId, tracks, true);
 		}.bind(this));
 };
 

--- a/app/models/index.js
+++ b/app/models/index.js
@@ -3,6 +3,7 @@ var models = {};
 
 module.exports = models;
 
+models.AbstractModel = require('./lib/abstract-model');
 models.Album = require('./lib/album');
 models.AudioTrack = require('./lib/audio-track');
 models.Config = require('./lib/config');

--- a/app/models/lib/abstract-model.js
+++ b/app/models/lib/abstract-model.js
@@ -1,0 +1,40 @@
+var events = require('events');
+
+
+
+/**
+ * @param {INPUT_TYPE=} opt_data
+ * @constructor
+ * @template INPUT_TYPE
+ */
+var AbstractModel = function(opt_data) {
+	goog.base(this);
+
+	if (opt_data) {
+		this.parse(opt_data);
+	}
+};
+goog.inherits(AbstractModel, events.EventEmitter);
+
+
+/**
+ * @param {INPUT_TYPE} data
+ */
+AbstractModel.prototype.parse = function(data) {
+	data = data || {};
+};
+
+
+/**
+ * @param {Array=} array
+ * @param {*} model
+ * @return Array
+ */
+AbstractModel.prototype.parseArray = function(array, model) {
+	return (array || []).map(function(arrayItem) {
+		return new model(arrayItem);
+	});
+};
+
+
+module.exports = AbstractModel;

--- a/app/models/lib/audio-track.js
+++ b/app/models/lib/audio-track.js
@@ -98,7 +98,7 @@ AudioTrack.prototype._parseYandexMusic = function(data) {
 
 
 AudioTrack.prototype._getVKUrl = function() {
-	return new Promise(function(resolve, reject) {
+	return new vknp.Promise(function(resolve, reject) {
 		resolve(this.url);
 	}.bind(this));
 };

--- a/app/models/lib/audio-track.js
+++ b/app/models/lib/audio-track.js
@@ -33,6 +33,9 @@ AudioTrack.prototype.parse = function(data) {
 	} else if (data instanceof vknp.api.yandexMusic.models.Track) {
 		this._parseYandexMusic(data);
 		this._apiType = AudioTrack.Api.YANDEX_MUSIC;
+
+	} else {
+		this._parseOther(data);
 	}
 };
 
@@ -48,6 +51,8 @@ AudioTrack.prototype.getUrl = function() {
 		case AudioTrack.Api.YANDEX_MUSIC:
 			return this._getYandexMusicUrl();
 			break;
+		default:
+			return this._getOtherUrl();
 	}
 };
 
@@ -97,6 +102,15 @@ AudioTrack.prototype._parseYandexMusic = function(data) {
 };
 
 
+AudioTrack.prototype._parseOther = function(data) {
+	/** @type {string} */
+	this.title = data.title || '';
+
+	/** @type {string} */
+	this.url = data.url;
+};
+
+
 AudioTrack.prototype._getVKUrl = function() {
 	return new vknp.Promise(function(resolve, reject) {
 		resolve(this.url);
@@ -106,6 +120,18 @@ AudioTrack.prototype._getVKUrl = function() {
 
 AudioTrack.prototype._getYandexMusicUrl = function() {
 	return app.api.yandexMusic.getTrackUrl(this.id, this.storageDir);
+};
+
+
+/**
+ *
+ * @return {Promise.<string>}
+ * @protected
+ */
+AudioTrack.prototype._getOtherUrl = function() {
+	return new vknp.Promise(function(resolve, reject) {
+		resolve(this.url);
+	}.bind(this));
 };
 
 

--- a/app/models/lib/audio-track.js
+++ b/app/models/lib/audio-track.js
@@ -6,25 +6,49 @@
  * To change this template use File | Settings | File Templates.
  */
 
+var models = require('../');
+
+
+
 /**
  * @param {Object} data
  * @constructor
  */
 var AudioTrack = function(data) {
-	data = data || {};
+	goog.base(this, data);
+};
+goog.inherits(AudioTrack, models.AbstractModel);
 
-	/** @type {string} */
-	this.artist = data['artist'] || '';
-	/** @type {string} */
-	this.title = data['title'] || '';
-	/** @type {string} */
-	this.duration = data['duration'] || 0;
 
+/**
+ * @inheritDoc
+ */
+AudioTrack.prototype.parse = function(data) {
+	goog.base(this, 'parse');
+
+	if (data instanceof vknp.api.vk.models.AudioTrack) {
+		this._parseVK(data);
+		this._apiType = AudioTrack.Api.VK;
+
+	} else if (data instanceof vknp.api.yandexMusic.models.Track) {
+		this._parseYandexMusic(data);
+		this._apiType = AudioTrack.Api.YANDEX_MUSIC;
+	}
 };
 
 
+/**
+ * @return {Promise.<string>}
+ */
 AudioTrack.prototype.getUrl = function() {
-
+	switch (this._apiType) {
+		case AudioTrack.Api.VK:
+			return this._getVKUrl();
+			break;
+		case AudioTrack.Api.YANDEX_MUSIC:
+			return this._getYandexMusicUrl();
+			break;
+	}
 };
 
 /**
@@ -35,31 +59,62 @@ AudioTrack.prototype.toString = function() {
 };
 
 
+AudioTrack.prototype._parseVK = function(data) {
+	/** @type {string} */
+	this.artist = data.artist || '';
+
+	/** @type {string} */
+	this.title = data.title || '';
+
+	/** @type {string} */
+	this.duration = data.durationMillis || data.durationMs || 0;
+
+	/** @type {?number} */
+	this.id = data.id || null;
+
+	this.url = (function() {
+		var index = data.url.indexOf('?');
+		return data.url.substr(0, index);
+	})();
+};
+
+
+AudioTrack.prototype._parseYandexMusic = function(data) {
+	/** @type {string} */
+	this.artist = data.artist || '';
+
+	/** @type {string} */
+	this.title = data.title || '';
+
+	/** @type {string} */
+	this.duration = data.duration || 0;
+
+	/** @type {?number} */
+	this.id = data.id || null;
+
+	/** @type {string} */
+	this.storageDir = data.storageDir;
+};
+
+
+AudioTrack.prototype._getVKUrl = function() {
+	return new Promise(function(resolve, reject) {
+		resolve(this.url);
+	}.bind(this));
+};
+
+
+AudioTrack.prototype._getYandexMusicUrl = function() {
+	return app.api.yandexMusic.getTrackUrl(this.id, this.storageDir);
+};
+
+
 /**
- * @enum {number}
+ * @enum {string}
  */
-AudioTrack.genreType = {
-	ROCK: 1,
-	POP: 2,
-	RAP_AND_HIP_HOP: 3,
-	EASY_LISTENING: 4,
-	DANCE_AND_HOUSE: 5,
-	INSTRUMENTAL: 6,
-	METAL: 7,
-	ALTERNATIVE: 21,
-	DUBSTEP: 8,
-	JAZZ_AND_BLUES: 9,
-	DRUM_AND_BASS: 10,
-	TRANCE: 11,
-	CHANSON: 12,
-	ETHNIC: 13,
-	ACOUSTIC_AND_VOCAL: 14,
-	REGGAE: 15,
-	CLASSICAL: 16,
-	INDIE_POP: 17,
-	SPEECH: 19,
-	ELECTROPOP_AND_DISCO: 22,
-	OTHER: 18
+AudioTrack.Api = {
+	VK: 'vk',
+	YANDEX_MUSIC: 'yandex-music'
 };
 
 

--- a/app/service/lib/play-list-manager.js
+++ b/app/service/lib/play-list-manager.js
@@ -98,6 +98,17 @@ PlayListManager.prototype.addItems = function(id, tracks) {
 };
 
 
+/**
+ * @param {number} id
+ * @param {Array.<vknp.models.AudioTrack>} tracks
+ * @return {?number}
+ */
+PlayListManager.prototype.setItems = function(id, tracks) {
+	this.clear(id);
+	this.addItems(id, tracks);
+};
+
+
 
 /**
  * @param {number} id

--- a/app/service/lib/player/lib/player.js
+++ b/app/service/lib/player/lib/player.js
@@ -153,17 +153,21 @@ Player.prototype._play = function() {
 	if (this._player) {
 		this._player.deinit();
 	}
-	this._player = new p(track.url);
-	this._state = this.state.PLAY;
-	this.emit(this.EVENT_PLAY, {
-		track: playlist.current(),
-		position: playlist.currentIndex(),
-		playlistId: app.service.playListManager.getActivePlaylistId(),
-		isStream: this._player._isStream()
-	});
+	track.getUrl()
+		.then(function(url) {
+			this._player = new p(url);
+			this._state = this.state.PLAY;
 
-	this._player.on(this._player.EVENT_STOP, this._afterStop.bind(this));
-	this._player.on(this._player.EVENT_ERROR, this._afterStop.bind(this));
+			this.emit(this.EVENT_PLAY, {
+				track: playlist.current(),
+				position: playlist.currentIndex(),
+				playlistId: app.service.playListManager.getActivePlaylistId(),
+				isStream: this._player._isStream()
+			});
+
+			this._player.on(this._player.EVENT_STOP, this._afterStop.bind(this));
+			this._player.on(this._player.EVENT_ERROR, this._afterStop.bind(this));
+		}.bind(this));
 };
 
 

--- a/app/service/lib/radio.js
+++ b/app/service/lib/radio.js
@@ -54,7 +54,10 @@ Radio.prototype._parse = function(resolve, reject, readStream) {
 
 Radio.prototype._makeAudioTracks = function(resolve, m3uItems) {
 	var audioTracks = m3uItems['PlaylistItem'].map(function(item) {
-		return new vknp.models.AudioTrack(item.properties);
+		return new vknp.models.AudioTrack({
+			title: item.properties.title,
+			url: item.properties.uri
+		});
 	});
 	resolve(audioTracks);
 };

--- a/app/ui/console/panels/lib/playlist.js
+++ b/app/ui/console/panels/lib/playlist.js
@@ -43,9 +43,13 @@ goog.inherits(PlayList, BasePanel);
 
 
 /**
- * @param {DataList.<AudioTrack>} tracks
+ * @param {Array.<vknp.api.yandexMusic.models.Track|vknp.api.vk.models.AudioTrack>} tracks
  */
 PlayList.prototype.setContent = function(tracks) {
+	tracks = tracks.map(function(track) {
+		return new vknp.models.AudioTrack(track);
+	});
+
 	var playlist = this.getPlaylist();
 	if (playlist) {
 		playlist.setItems(tracks);


### PR DESCRIPTION
- Add abstract-model for vknp
- Refactoring rename variable in yandex-music-abstract-model
- Add abstract-model for vknp
- Change arguments for YandexMusic.prototype.getTrackUrl
- Update audio-track-model for universality
- Add VK.prototype.getAudioTrackById
- Update Player.prototype._play for use universal-audio-track-model
- Require promise as vknp.Promise
- Use vknp.Promise in audio-track-model
- Build audio-track-global-model from another audio-models in PlayList.prototype.setContent
- Add method PlayListManager.prototype.setItems
- Refactor Vknp.prototype.search - use PlayList.prototype.setContent
- Add parse to other data in vknp.models.AudioModel
- Fix make audio-track-model in radio-service
- Merge branch 'develop' into feature/16-add-universal-audio-model
